### PR TITLE
Standards and architecture tweaks.

### DIFF
--- a/stream.php
+++ b/stream.php
@@ -127,7 +127,7 @@ class ArchiveStream
 	 */
 	public function push_error($message)
 	{
-		$this->errors[] = $message;
+		$this->errors[] = (string) $message;
 	}
 	
 	/**


### PR DESCRIPTION
Coding standards fix, and casting inputs to public methods to prevent possible type errors.
