### PR TITLE
Add mb-string requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "license": "MIT",
     "require": {
         "php": ">=5.1.2",
-        "ext-gmp": "*"
+        "ext-gmp": "*",
+        "ext-mbstring": "*"
     },
     "autoload": {
 		"psr-4": {


### PR DESCRIPTION
mbstring extension methods are used but the requirement for the extension is not noted in the composer.json - see: [here](https://github.com/barracudanetworks/ArchiveStream-php/blob/3eaa040f49c878566768af55e6af98b2e8f6490a/src/ZipArchive.php#L224).

Updated composer.json to reflect this requirement.