### PR TITLE
File attribute flag got lost

### DIFF
--- a/src/ZipArchive.php
+++ b/src/ZipArchive.php
@@ -272,11 +272,12 @@ class ZipArchive extends Archive
 	 * @param int    $len     Uncompressed size.
 	 * @param int    $rec_len Size of the record.
 	 * @param int    $genb    General purpose bit flag.
+	 * @param int    $fattr   File attribute bit flag.
 	 * @return void
 	 */
-	private function add_to_cdr($name, array $opt, $meth, $crc, $zlen, $len, $rec_len, $genb = 0)
+	private function add_to_cdr($name, array $opt, $meth, $crc, $zlen, $len, $rec_len, $genb = 0, $fattr = 0x20)
 	{
-		$this->files[] = array($name, $opt, $meth, $crc, $zlen, $len, $this->cdr_ofs, $genb);
+		$this->files[] = array($name, $opt, $meth, $crc, $zlen, $len, $this->cdr_ofs, $genb, $fattr);
 		$this->cdr_ofs += $rec_len;
 	}
 


### PR DESCRIPTION
Thanks for great lib!
Not sure how to call the variable and if the default value is OK, but my point is that it's not passed further. Perhaps this could also cause some problems for the Windows users as I could see in issues...

**update**
FYI: Sadly this still doesn't fix problems with ZIP files larger than 4GB on Windows
