### PR TITLE
 Fix output stream for web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A library for dynamically streaming dynamic tar or zip files without the need to
  *   $name          - Name of output file (optional).
  *   $opt           - Hash of archive options (optional, see "Archive Options"
  *                    below).
- *   $output_stream - Output stream for archive (optional - defaults to STDOUT)
+ *   $output_stream - Output stream for archive (optional - defaults to php://output)
  *
  * Archive Options:
  *

--- a/src/Archive.php
+++ b/src/Archive.php
@@ -59,10 +59,15 @@ class Archive
 		$name = null,
 		array $opt = array(),
 		$base_path = null,
-		$output_stream = STDOUT
+		$output_stream = null
 	)
-	{
-		$this->output_stream = $output_stream;
+	{        
+                if ($output_stream === null) {
+                    // Output stream for cli and web server
+                    $output_stream = fopen('php://output', 'w');
+                }
+
+        	$this->output_stream = $output_stream;
 
 		// save options
 		$this->opt = $opt;
@@ -106,9 +111,14 @@ class Archive
 	public static function instance_by_useragent(
 		$base_filename = null,
 		array $opt = array(),
-		$output_stream = STDOUT
+		$output_stream = null
 	)
 	{
+                if ($output_stream === null) {
+                    // Output stream for cli and web server
+                    $output_stream = fopen('php://output', 'w');
+                }
+
 		$user_agent = (isset($_SERVER['HTTP_USER_AGENT']) ? strtolower($_SERVER['HTTP_USER_AGENT']) : '');
 
 		// detect windows and use zip

--- a/src/Archive.php
+++ b/src/Archive.php
@@ -101,7 +101,7 @@ class Archive
 	 * @param string   $base_filename A name for the resulting archive (without an extension).
 	 * @param array    $opt           Map of archive options (see above for list).
 	 * @param resource $output_stream Output stream for archive contents.
-	 * @return ArchiveStream for either zip or tar
+	 * @return Zip|Tar for either zip or tar
 	 */
 	public static function instance_by_useragent(
 		$base_filename = null,


### PR DESCRIPTION
STDOUT is only working in CLI SAPI. It doesn't work in a web framework (Symfony), use "php://output" instead.
"php://output" is also compatible with php CLI SAPI.